### PR TITLE
Add "or" operator handler for refine filters

### DIFF
--- a/src/FirestoreDatabase.ts
+++ b/src/FirestoreDatabase.ts
@@ -26,8 +26,12 @@ export class FirestoreDatabase extends BaseDatabase {
     getFilterQuery({ resource, sort, filters }: IGetList): (CollectionReference<DocumentData> | Query<DocumentData>) {
         const ref = this.getCollectionRef(resource);
         let queryFilter = filters?.map(filter => {
-            const operator = getFilterOperator(filter.operator);
-            return where(filter.field, operator, filter.value);
+            if (filter.operator !== "or") {
+                const operator = getFilterOperator(filter.operator);
+                return where(filter.field, operator, filter.value);
+            } else {
+                // TODO: implement "or" operator filters for firebase
+            }
         });
         let querySorter = sort?.map(sorter => orderBy(sorter.field, sorter.order));
 


### PR DESCRIPTION
Hey @rturan29 ,

refine will soon release a version that will add support for the `or` operator for filtering. With the new version, `CrudFilters` will consist of two separate union types, so the `getFilterQuery` function will need to handle these two types.

The user will can create a filter as follows:

```ts
filter = [
    {
      operator: "eq",
      field: "age",
      value: 20
    },
    {
      operator: "or",
      value: [
        {
          field: "title",
          operator: "eq",
          value: "Test",
        },
        {
          field: "description",
          operator: "eq",
          value: "Test"
        }
      ]
   }
]
```

Here the query would look like `"age" == 20 AND ("title" == "Test" OR "description" == "Test")`

The `field` property will can be undefined so I made a small change to the your `getFilterQuery` function. When refine releases the new version, you can make some changes on this PR to add "or" operator support.

You can check out the [PR](https://github.com/pankod/refine/pull/1598) for more information about the new release.

If you need any help, feel free to reach out to me on discord.
Happy coding!
